### PR TITLE
Blue green service task

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform module to create an ECS Service for a web app (task), and an ALB targe
 
 ---
 
-This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps. 
+This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
 [<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
 [<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
 [<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
@@ -32,7 +32,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
-We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out! 
+We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
 
 
 
@@ -158,6 +158,7 @@ Available targets:
 | container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
 | container_port | The port on the container to associate with the load balancer | string | `80` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| deployment_type | Whether to use the standard ECS or CODE_DEPLOY for (blue/green) | string | `ECS` | no |
 | deployment_maximum_percent | The upper limit of the number of tasks (as a percentage of `desired_count`) that can be running in a service during a deployment | string | `200` | no |
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |
@@ -192,9 +193,9 @@ Available targets:
 
 
 
-## Share the Love 
+## Share the Love
 
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task)! (it helps us **a lot**) 
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task)! (it helps us **a lot**)
 
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
@@ -225,9 +226,9 @@ File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-alb-servic
 
 ## Commercial Support
 
-Work directly with our team of DevOps experts via email, slack, and video conferencing. 
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
 
-We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer.
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)][email]
 
@@ -237,7 +238,7 @@ We provide [*commercial support*][commercial_support] for all of our [Open Sourc
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll [develop original modules][module_development] to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures.
 
 
 
@@ -252,7 +253,7 @@ Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Ou
 
 ## Newsletter
 
-Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
+Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
 
 ## Contributing
 
@@ -281,9 +282,9 @@ Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
-## License 
+## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 
@@ -324,7 +325,7 @@ This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? P
 
 We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We ❤️  [Open Source Software][we_love_open_source].
 
-We offer [paid support][commercial_support] on all of our projects.  
+We offer [paid support][commercial_support] on all of our projects.
 
 Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,6 +9,7 @@
 | container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
 | container_port | The port on the container to associate with the load balancer | string | `80` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
+| deployment_type | Whether to use ECS or CODE_DEPLOY for deployments | string | `ECS` | no |
 | deployment_maximum_percent | The upper limit of the number of tasks (as a percentage of `desired_count`) that can be running in a service during a deployment | string | `200` | no |
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,7 +9,7 @@
 | container_name | The name of the container in task definition to associate with the load balancer | string | - | yes |
 | container_port | The port on the container to associate with the load balancer | string | `80` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
-| deployment_type | Whether to use ECS or CODE_DEPLOY for deployments | string | `ECS` | no |
+| deployment_type | Whether to use the standard ECS or CODE_DEPLOY for (blue/green) | string | `ECS` | no |
 | deployment_maximum_percent | The upper limit of the number of tasks (as a percentage of `desired_count`) that can be running in a service during a deployment | string | `200` | no |
 | deployment_minimum_healthy_percent | The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment | string | `100` | no |
 | desired_count | The number of instances of the task definition to place and keep running | string | `1` | no |

--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,11 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   }
 
   lifecycle {
-    ignore_changes = ["task_definition"]
+    ignore_changes = [
+      "task_definition",
+      "load_balancer",
+      "desired_count"
+    ]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -188,6 +188,10 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   cluster                            = "${var.ecs_cluster_arn}"
   tags                               = "${module.default_label.tags}"
 
+  deployment_controller {
+    type = "${var.deployment_type}"
+  }
+
   network_configuration {
     security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]
     subnets          = ["${var.subnet_ids}"]
@@ -216,6 +220,10 @@ resource "aws_ecs_service" "default" {
   launch_type                        = "${var.launch_type}"
   cluster                            = "${var.ecs_cluster_arn}"
   tags                               = "${module.default_label.tags}"
+
+  deployment_controller {
+    type = "${var.deployment_type}"
+  }
 
   network_configuration {
     security_groups  = ["${var.security_group_ids}", "${aws_security_group.ecs_service.id}"]

--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
   launch_type                        = "${var.launch_type}"
   cluster                            = "${var.ecs_cluster_arn}"
-  tags                               = "${module.default_label.tags}"
+  #tags                               = "${module.default_label.tags}"
 
   deployment_controller {
     type = "${var.deployment_type}"
@@ -219,7 +219,7 @@ resource "aws_ecs_service" "default" {
   health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
   launch_type                        = "${var.launch_type}"
   cluster                            = "${var.ecs_cluster_arn}"
-  tags                               = "${module.default_label.tags}"
+  #tags                               = "${module.default_label.tags}"
 
   deployment_controller {
     type = "${var.deployment_type}"

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "deployment_minimum_healthy_percent" {
   default     = 100
 }
 
+variable "deployment_type" {
+  type        = "string"
+  description = "A string indicating the type of deployment ECS|CODE_DEPLOY"
+  default     = "ECS"
+}
+
 variable "health_check_grace_period_seconds" {
   type        = "string"
   description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers"


### PR DESCRIPTION
- Allows for the CODE_DEPLOY deployment type required by ECS w/Blue Green.
- Ignore service updates on LB and desired count updates as terraform should not push a deployment.
-- Deployment handled by Code Deploy or ECS.
- Comment out tags as we are yet to migrate to resource tagging.